### PR TITLE
hotfix

### DIFF
--- a/src/crepe/api/Config.h
+++ b/src/crepe/api/Config.h
@@ -11,19 +11,18 @@ namespace crepe {
  * modified *before* execution is handed over from the game programmer to the engine (i.e. the
  * main loop is started).
  */
-class Config {
+class Config final {
 public:
 	//! Retrieve handle to global Config instance
 	static Config & get_instance();
 
 private:
 	Config() = default;
-
-	// singleton
-	Config(const Config &) = delete;
-	Config(Config &&) = delete;
-	Config & operator=(const Config &) = delete;
-	Config & operator=(Config &&) = delete;
+	~Config() = default;
+	Config(const Config &) = default;
+	Config(Config &&) = default;
+	Config & operator=(const Config &) = default;
+	Config & operator=(Config &&) = default;
 
 public:
 	//! Logging-related settings

--- a/src/crepe/api/Texture.cpp
+++ b/src/crepe/api/Texture.cpp
@@ -9,14 +9,9 @@
 using namespace crepe;
 using namespace std;
 
-Texture::Texture(unique_ptr<Asset> res) {
+Texture::Texture(const Asset & src) {
 	dbg_trace();
-	this->load(std::move(res));
-}
-
-Texture::Texture(const char * src) {
-	dbg_trace();
-	this->load(make_unique<Asset>(src));
+	this->load(src);
 }
 
 Texture::~Texture() {
@@ -24,9 +19,9 @@ Texture::~Texture() {
 	this->texture.reset();
 }
 
-void Texture::load(unique_ptr<Asset> res) {
+void Texture::load(const Asset & res) {
 	SDLContext & ctx = SDLContext::get_instance();
-	this->texture = std::move(ctx.texture_from_path(res->get_path()));
+	this->texture = ctx.texture_from_path(res.get_path());
 }
 
 int Texture::get_width() const {

--- a/src/crepe/api/Texture.h
+++ b/src/crepe/api/Texture.h
@@ -25,16 +25,10 @@ class Texture {
 
 public:
 	/**
-	 * \brief Constructs a Texture from a file path.
-	 * \param src Path to the image file to be loaded as a texture.
-	 */
-	Texture(const char * src);
-
-	/**
 	 * \brief Constructs a Texture from an Asset resource.
-	 * \param res Unique pointer to an Asset resource containing texture data.
+	 * \param src Asset with texture data to load.
 	 */
-	Texture(std::unique_ptr<Asset> res);
+	Texture(const Asset & src);
 
 	/**
 	 * \brief Destroys the Texture instance, freeing associated resources.
@@ -59,7 +53,7 @@ private:
 	 * \brief Loads the texture from an Asset resource.
 	 * \param res Unique pointer to an Asset resource to load the texture from.
 	 */
-	void load(std::unique_ptr<Asset> res);
+	void load(const Asset & res);
 
 private:
 	//! The texture of the class from the library

--- a/src/test/AssetTest.cpp
+++ b/src/test/AssetTest.cpp
@@ -7,20 +7,16 @@ using namespace std;
 using namespace crepe;
 using namespace testing;
 
-class AssetTest : public Test {
-public:
+TEST(AssetTest, Existant) { ASSERT_NO_THROW(Asset{"asset/texture/img.png"}); }
+
+TEST(AssetTest, Nonexistant) { ASSERT_ANY_THROW(Asset{"asset/nonexistant"}); }
+
+TEST(AssetTest, Rootless) {
 	Config & cfg = Config::get_instance();
-	void SetUp() override { this->cfg.asset.root_pattern = ".crepe-root"; }
-};
-
-TEST_F(AssetTest, Existant) { ASSERT_NO_THROW(Asset{"asset/texture/img.png"}); }
-
-TEST_F(AssetTest, Nonexistant) { ASSERT_ANY_THROW(Asset{"asset/nonexistant"}); }
-
-TEST_F(AssetTest, Rootless) {
 	cfg.asset.root_pattern.clear();
 
 	string arbitrary = "\\/this is / /../passed through as-is";
 	Asset asset{arbitrary};
 	ASSERT_EQ(arbitrary, asset.get_path());
 }
+

--- a/src/test/RenderSystemTest.cpp
+++ b/src/test/RenderSystemTest.cpp
@@ -30,7 +30,7 @@ public:
 
 	void SetUp() override {
 		auto & sprite1
-			= entity1.add_component<Sprite>(make_shared<Texture>("../asset/texture/img.png"),
+			= entity1.add_component<Sprite>(make_shared<Texture>("asset/texture/img.png"),
 											Color(0, 0, 0, 0), FlipSettings{false, false});
 		ASSERT_NE(sprite1.sprite_image.get(), nullptr);
 		sprite1.order_in_layer = 5;
@@ -38,7 +38,7 @@ public:
 		EXPECT_EQ(sprite1.order_in_layer, 5);
 		EXPECT_EQ(sprite1.sorting_in_layer, 5);
 		auto & sprite2
-			= entity2.add_component<Sprite>(make_shared<Texture>("../asset/texture/img.png"),
+			= entity2.add_component<Sprite>(make_shared<Texture>("asset/texture/img.png"),
 											Color(0, 0, 0, 0), FlipSettings{false, false});
 		ASSERT_NE(sprite2.sprite_image.get(), nullptr);
 		sprite2.sorting_in_layer = 2;
@@ -48,7 +48,7 @@ public:
 		EXPECT_EQ(sprite2.order_in_layer, 1);
 
 		auto & sprite3
-			= entity3.add_component<Sprite>(make_shared<Texture>("../asset/texture/img.png"),
+			= entity3.add_component<Sprite>(make_shared<Texture>("asset/texture/img.png"),
 											Color(0, 0, 0, 0), FlipSettings{false, false});
 		ASSERT_NE(sprite3.sprite_image.get(), nullptr);
 		sprite3.sorting_in_layer = 1;
@@ -58,7 +58,7 @@ public:
 		EXPECT_EQ(sprite3.order_in_layer, 2);
 
 		auto & sprite4
-			= entity4.add_component<Sprite>(make_shared<Texture>("../asset/texture/img.png"),
+			= entity4.add_component<Sprite>(make_shared<Texture>("asset/texture/img.png"),
 											Color(0, 0, 0, 0), FlipSettings{false, false});
 		ASSERT_NE(sprite4.sprite_image.get(), nullptr);
 		sprite4.sorting_in_layer = 1;

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -1,15 +1,31 @@
-#include <crepe/api/Config.h>
-
 #include <gtest/gtest.h>
+
+#define protected public
+#define private public
+
+#include <crepe/api/Config.h>
 
 using namespace crepe;
 using namespace testing;
 
+class GlobalConfigReset : public EmptyTestEventListener {
+public:
+	Config & cfg = Config::get_instance();
+	Config cfg_default = Config();
+
+	// This function is called before each test
+	void OnTestStart(const TestInfo &) override {
+		cfg = cfg_default;
+		cfg.log.level = Log::Level::WARNING;
+	}
+};
+
 int main(int argc, char ** argv) {
 	InitGoogleTest(&argc, argv);
 
-	auto & cfg = Config::get_instance();
-	cfg.log.level = Log::Level::ERROR;
+	UnitTest & ut = *UnitTest::GetInstance();
+	ut.listeners().Append(new GlobalConfigReset);
 
 	return RUN_ALL_TESTS();
 }
+


### PR DESCRIPTION
nu:
- Reset Config voor elke testcase (verbetert testbaarheid van klassen die afhankelijk zijn van Config)
  - Hierbij ook de plotse realisatie dat Asset afhankelijk is van Config en zelf geen singleton is, het zelfde geldde hiervoor al voor Log maar ik dacht dat dat de enige was. Nu lijkt het me toch een beter idee om Config ook een singleton te houden en er maar gewoon mee te leven nu de testbaarheid van Config verbeterd is.
- Constructor van Texture aangepast om alleen een `const Asset &` te nemen (dit wordt later als de ResourceManager implementatie definitief is toegevoegd aan een basis `Resource`-klasse en toegelicht in de internals documentatie)
- Relatieve paden in RenderSystemTest geupdatet