### PR TITLE
rendering fixes

### DIFF
--- a/src/crepe/api/Sprite.h
+++ b/src/crepe/api/Sprite.h
@@ -66,6 +66,16 @@ public:
 
 		//! independent sprite offset position
 		vec2 position_offset;
+
+		/**
+		 * \brief gives the user the option to render this in world space or in camera space
+		 *
+		 * - if true will this be rendered in world space this means that the sprite can be
+		 *   rendered off the screen 
+		 * - if false --> will the sprite be rendered in camera space. this means that the
+		 *   coordinates given on the \c Sprite and \c Transform will be inside the camera 
+		 */
+		bool world_space = true;
 	};
 
 public:

--- a/src/crepe/facade/SDLContext.cpp
+++ b/src/crepe/facade/SDLContext.cpp
@@ -11,9 +11,7 @@
 #include <array>
 #include <cmath>
 #include <cstddef>
-#include <cstdint>
 #include <functional>
-#include <iostream>
 #include <memory>
 #include <stdexcept>
 
@@ -149,13 +147,11 @@ SDL_FRect SDLContext::get_dst_rect(const DestinationRectangleData & ctx) const {
 	size *= cam_aux_data.render_scale * ctx.img_scale * data.scale_offset;
 
 	if (ctx.sprite.data.world_space) {
-		cout << "world_space" << endl;
 		vec2 multiplier = cam_aux_data.cam_pos
 						  + (cam_aux_data.zoomed_viewport / 2) * cam_aux_data.render_scale
 						  - size / 2 + cam_aux_data.bar_size;
 		screen_pos += multiplier;
 	} else {
-		cout << "camera space" << endl;
 		vec2 multiplier = (cam_aux_data.zoomed_viewport / 2) * cam_aux_data.render_scale
 						  - size / 2 + cam_aux_data.bar_size;
 		screen_pos += multiplier;

--- a/src/crepe/facade/SDLContext.cpp
+++ b/src/crepe/facade/SDLContext.cpp
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <iostream>
 #include <memory>
 #include <stdexcept>
 
@@ -137,6 +138,9 @@ SDL_FRect SDLContext::get_dst_rect(const DestinationRectangleData & ctx) const {
 		= (ctx.sprite.aspect_ratio == 0) ? ctx.texture.get_ratio() : ctx.sprite.aspect_ratio;
 
 	vec2 size = data.size;
+	vec2 screen_pos = ctx.pos + data.position_offset;
+
+
 	if (data.size.x == 0 && data.size.y != 0) {
 		size.x = data.size.y * aspect_ratio;
 	}
@@ -145,10 +149,15 @@ SDL_FRect SDLContext::get_dst_rect(const DestinationRectangleData & ctx) const {
 	}
 	size *= cam_aux_data.render_scale * ctx.img_scale * data.scale_offset;
 
-	vec2 screen_pos = (ctx.pos + data.position_offset - cam_aux_data.cam_pos
-					   + (cam_aux_data.zoomed_viewport) / 2)
-						  * cam_aux_data.render_scale
-					  - size / 2 + cam_aux_data.bar_size;
+	if (ctx.sprite.data.world_space) {
+		cout << "world_space" << endl;
+		vec2 multiplier = cam_aux_data.cam_pos + (cam_aux_data.zoomed_viewport / 2) * cam_aux_data.render_scale - size / 2 + cam_aux_data.bar_size;
+		screen_pos += multiplier;
+	} else {
+		cout << "camera space" << endl;
+		vec2 multiplier = (cam_aux_data.zoomed_viewport / 2) * cam_aux_data.render_scale - size / 2 + cam_aux_data.bar_size;
+		screen_pos += multiplier;
+	}
 
 	return SDL_FRect{
 		.x = screen_pos.x,

--- a/src/crepe/facade/SDLContext.cpp
+++ b/src/crepe/facade/SDLContext.cpp
@@ -140,7 +140,6 @@ SDL_FRect SDLContext::get_dst_rect(const DestinationRectangleData & ctx) const {
 	vec2 size = data.size;
 	vec2 screen_pos = ctx.pos + data.position_offset;
 
-
 	if (data.size.x == 0 && data.size.y != 0) {
 		size.x = data.size.y * aspect_ratio;
 	}
@@ -151,11 +150,14 @@ SDL_FRect SDLContext::get_dst_rect(const DestinationRectangleData & ctx) const {
 
 	if (ctx.sprite.data.world_space) {
 		cout << "world_space" << endl;
-		vec2 multiplier = cam_aux_data.cam_pos + (cam_aux_data.zoomed_viewport / 2) * cam_aux_data.render_scale - size / 2 + cam_aux_data.bar_size;
+		vec2 multiplier = cam_aux_data.cam_pos
+						  + (cam_aux_data.zoomed_viewport / 2) * cam_aux_data.render_scale
+						  - size / 2 + cam_aux_data.bar_size;
 		screen_pos += multiplier;
 	} else {
 		cout << "camera space" << endl;
-		vec2 multiplier = (cam_aux_data.zoomed_viewport / 2) * cam_aux_data.render_scale - size / 2 + cam_aux_data.bar_size;
+		vec2 multiplier = (cam_aux_data.zoomed_viewport / 2) * cam_aux_data.render_scale
+						  - size / 2 + cam_aux_data.bar_size;
 		screen_pos += multiplier;
 	}
 

--- a/src/crepe/system/RenderSystem.cpp
+++ b/src/crepe/system/RenderSystem.cpp
@@ -73,7 +73,8 @@ void RenderSystem::update() {
 	this->present_screen();
 }
 
-bool RenderSystem::render_particle(const Sprite & sprite, const double & scale) {
+bool RenderSystem::render_particle(const Sprite & sprite, const float & transform_angle,
+								   const float & scale) {
 
 	ComponentManager & mgr = this->mediator.component_manager;
 	SDLContext & ctx = this->mediator.sdl_context;
@@ -92,12 +93,13 @@ bool RenderSystem::render_particle(const Sprite & sprite, const double & scale) 
 
 		for (const Particle & p : em.particles) {
 			if (!p.active) continue;
+			if (p.time_in_life < em.data.begin_lifespan) continue;
 
 			ctx.draw(SDLContext::RenderContext{
 				.sprite = sprite,
 				.texture = res,
 				.pos = p.position,
-				.angle = p.angle,
+				.angle = p.angle + transform_angle,
 				.scale = scale,
 			});
 		}
@@ -136,7 +138,8 @@ void RenderSystem::render() {
 		const Transform & transform
 			= mgr.get_components_by_id<Transform>(sprite.game_object_id).front().get();
 
-		bool rendered_particles = this->render_particle(sprite, transform.scale);
+		bool rendered_particles
+			= this->render_particle(sprite, transform.rotation, transform.scale);
 
 		if (rendered_particles) continue;
 

--- a/src/crepe/system/RenderSystem.h
+++ b/src/crepe/system/RenderSystem.h
@@ -49,7 +49,8 @@ private:
 	 *  constructor is now protected i cannot make tmp inside
 	 * \return true if particles have been rendered
 	 */
-	bool render_particle(const Sprite & sprite, const double & scale);
+	bool render_particle(const Sprite & sprite, const float & transform_angle,
+						 const float & scale);
 	/**
 	 * \brief Renders all Text components
 	 *

--- a/src/example/rendering_particle.cpp
+++ b/src/example/rendering_particle.cpp
@@ -13,7 +13,6 @@
 #include <crepe/manager/ComponentManager.h>
 #include <crepe/manager/Mediator.h>
 #include <crepe/types.h>
-#include <iostream>
 
 using namespace crepe;
 using namespace std;
@@ -21,11 +20,7 @@ using namespace std;
 class TestScene : public Scene {
 public:
 	void load_scene() {
-
-		cout << "TestScene" << endl;
-		Mediator & mediator = this->mediator;
-		ComponentManager & mgr = mediator.component_manager;
-		GameObject game_object = mgr.new_object("", "", vec2{0, 0}, 0, 1);
+		GameObject game_object = new_object("", "", vec2{0, 0}, 0, 1);
 
 		Color color(255, 255, 255, 255);
 
@@ -41,25 +36,13 @@ public:
 					 .angle_offset = 0,
 					 .position_offset = {0, 0},
 				 });
+		auto & emitter = game_object.add_component<ParticleEmitter>(test_sprite, ParticleEmitter::Data{});
 
-		//auto & anim = game_object.add_component<Animator>(test_sprite,ivec2{32, 64}, uvec2{4,1}, Animator::Data{});
-		//anim.set_anim(0);
-
-		auto & cam = game_object.add_component<Camera>(ivec2{720, 1280}, vec2{400, 400},
+		auto & cam = game_object.add_component<Camera>(ivec2{1280, 720}, vec2{400, 400},
 													   Camera::Data{
 														   .bg_color = Color::WHITE,
 													   });
-
-		function<void()> on_click = [&]() { cout << "button clicked" << std::endl; };
-		function<void()> on_enter = [&]() { cout << "enter" << std::endl; };
-		function<void()> on_exit = [&]() { cout << "exit" << std::endl; };
-
-		auto & button
-			= game_object.add_component<Button>(vec2{200, 200}, vec2{0, 0}, on_click, false);
-		button.on_mouse_enter = on_enter;
-		button.on_mouse_exit = on_exit;
-		button.is_toggle = true;
-		button.active = true;
+		cam.data.postion_offset = {1000,1000};
 	}
 
 	string get_name() const { return "TestScene"; };

--- a/src/example/rendering_particle.cpp
+++ b/src/example/rendering_particle.cpp
@@ -36,13 +36,14 @@ public:
 					 .angle_offset = 0,
 					 .position_offset = {0, 0},
 				 });
-		auto & emitter = game_object.add_component<ParticleEmitter>(test_sprite, ParticleEmitter::Data{});
+		auto & emitter
+			= game_object.add_component<ParticleEmitter>(test_sprite, ParticleEmitter::Data{});
 
 		auto & cam = game_object.add_component<Camera>(ivec2{1280, 720}, vec2{400, 400},
 													   Camera::Data{
 														   .bg_color = Color::WHITE,
 													   });
-		cam.data.postion_offset = {1000,1000};
+		cam.data.postion_offset = {1000, 1000};
 	}
 
 	string get_name() const { return "TestScene"; };


### PR DESCRIPTION
This PR:
- world_space boolean added to sprite so that sprites can be renderd either in world space or camera space.
- particle rendering begin lifespan