### PR TITLE
Bug fixes

### DIFF
--- a/game/preview/NpcSubScene.cpp
+++ b/game/preview/NpcSubScene.cpp
@@ -49,7 +49,7 @@ NpcSubScene::NpcSubScene(Scene & scn) {
 			.looping = true,
 		}
 	);
-	npc.add_component<BoxCollider>(vec2 {50, 50});
+	npc.add_component<BoxCollider>(vec2 {40, 50});
 
 	npc.add_component<Rigidbody>(Rigidbody::Data {
 		.mass = 10,

--- a/game/preview/PrevPlayerScript.cpp
+++ b/game/preview/PrevPlayerScript.cpp
@@ -66,7 +66,8 @@ bool PrevPlayerScript::key_pressed(const KeyPressEvent & ev) {
 			this->head->data.position_offset -= 10;
 			break;
 		case Keycode::P:
-			this->get_component<AudioSource>().active = true;
+			this->get_components_by_name<AudioSource>("background_music").front().get().active
+				= true;
 			break;
 		case Keycode::J:
 			this->get_components_by_name<Transform>("camera").front().get().position.x

--- a/game/preview/PrevPlayerScript.cpp
+++ b/game/preview/PrevPlayerScript.cpp
@@ -66,7 +66,7 @@ bool PrevPlayerScript::key_pressed(const KeyPressEvent & ev) {
 			this->head->data.position_offset -= 10;
 			break;
 		case Keycode::P:
-			this->get_component<AudioSource>().play();
+			this->get_component<AudioSource>().active = true;
 			break;
 		case Keycode::J:
 			this->get_components_by_name<Transform>("camera").front().get().position.x

--- a/game/preview/PrevPlayerSubScene.cpp
+++ b/game/preview/PrevPlayerSubScene.cpp
@@ -76,7 +76,7 @@ PrevPlayerSubScene::PrevPlayerSubScene(Scene & scn) {
 		.collision_layers = {COLL_LAY_BOT_TOP, 100},
 		.collision_layer = COLL_LAY_PLAYER,
 	});
-	player.add_component<BoxCollider>(vec2(50, 50));
+	player.add_component<BoxCollider>(vec2(40, 50));
 	player.add_component<BehaviorScript>().set_script<PrevPlayerScript>();
 
 	AudioSource & audio = player.add_component<AudioSource>(Asset {"asset/music/level.ogg"});

--- a/game/preview/PrevPlayerSubScene.cpp
+++ b/game/preview/PrevPlayerSubScene.cpp
@@ -79,7 +79,8 @@ PrevPlayerSubScene::PrevPlayerSubScene(Scene & scn) {
 	player.add_component<BoxCollider>(vec2(40, 50));
 	player.add_component<BehaviorScript>().set_script<PrevPlayerScript>();
 
-	AudioSource & audio = player.add_component<AudioSource>(Asset {"asset/music/level.ogg"});
+	GameObject music = scn.new_object("background_music", "background_music");
+	AudioSource & audio = music.add_component<AudioSource>(Asset {"asset/music/level.ogg"});
 	audio.loop = true;
 	audio.play_on_awake = true;
 	audio.active = false;

--- a/game/preview/PrevPlayerSubScene.cpp
+++ b/game/preview/PrevPlayerSubScene.cpp
@@ -78,5 +78,9 @@ PrevPlayerSubScene::PrevPlayerSubScene(Scene & scn) {
 	});
 	player.add_component<BoxCollider>(vec2(50, 50));
 	player.add_component<BehaviorScript>().set_script<PrevPlayerScript>();
-	player.add_component<AudioSource>(Asset {"asset/music/level.ogg"}).stop();
+
+	AudioSource & audio = player.add_component<AudioSource>(Asset {"asset/music/level.ogg"});
+	audio.loop = true;
+	audio.play_on_awake = true;
+	audio.active = false;
 }


### PR DESCRIPTION
Het is nu niet meer mogelijk om (oneindig) veel Audio's te starten in de PreviewScene (door op P te drukken).
De Audio in de PreviewScene stopt nu bij het verlaten van deze Scene.
De hitbox van de Player en NPC (in de PreviewScene) kloppen nu (zijn nu hetzelfde als in de game).